### PR TITLE
METRON-813: Migrate metron-bro-plugin-kafka to be a bro package

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+   Apache Metron
+   Copyright 2015-2016 The Apache Software Foundation
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The goal in this example is to send all HTTP and DNS records to a Kafka topic na
  * Defining `logs_to_send` will ensure that only HTTP and DNS records are sent.
 
 ```
-@load Apache/Kafka/logs-to-kafka.bro
+@load metron-bro-plugin-kafka/Bro/Kafka
 redef Kafka::logs_to_send = set(HTTP::LOG, DNS::LOG);
 redef Kafka::topic_name = "bro";
 redef Kafka::kafka_conf = table(
@@ -60,7 +60,7 @@ It is also possible to send each log stream to a uniquely named topic.  The goal
  * Each log writer accepts a separate configuration table.
 
 ```
-@load Apache/Kafka/logs-to-kafka.bro
+@load metron-bro-plugin-kafka/Bro/Kafka
 redef Kafka::topic_name = "";
 redef Kafka::tag_json = T;
 
@@ -98,7 +98,7 @@ You may want to configure bro to filter log messages with certain characteristic
  * If the log message contains a 128 byte long source or destination IP address, the log is not sent to kafka.
 
 ```
-@load Apache/Kafka/logs-to-kafka.bro
+@load metron-bro-plugin-kafka/Bro/Kafka
 redef Kafka::topic_name = "bro";
 redef Kafka::tag_json = T;
 
@@ -237,7 +237,7 @@ ${KAFKA_HOME}/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.Si
 
 The following is how the `${BRO_HOME}/share/bro/site/local.bro` looks:
 ```
-@load Apache/Kafka/logs-to-kafka.bro
+@load metron-bro-plugin-kafka/Bro/Kafka
 redef Kafka::logs_to_send = set(HTTP::LOG, DNS::LOG);
 redef Kafka::topic_name = "bro";
 redef Kafka::tag_json = T;

--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -1,0 +1,16 @@
+[package]
+description = A Bro log writer plugin that sends logging output to Kafka.
+tags = log writer, bro plugin, kafka
+script_dir = scripts
+build_command = ./configure --bro-dist=%(bro_dist)s --with-librdkafka=%(LIBRDKAFKA_ROOT)s && make
+test_command = ( cd tests && btest -d )
+plugin_dir = build
+config_files = scripts/init.bro
+version = 0.1
+depends =
+  bro >=2.5.0
+  bro-pkg >=1.2
+external_depends =
+  librdkafka ~0.9.4
+user_vars =
+  LIBRDKAFKA_ROOT [/usr/local/lib] "Path to librdkafka installation tree"

--- a/scripts/Bro/Kafka/__load__.bro
+++ b/scripts/Bro/Kafka/__load__.bro
@@ -18,4 +18,4 @@
 # loaded automatically at that point.
 #
 
-@load ./init.bro
+@load ./logs-to-kafka.bro

--- a/tests/Baseline/kafka.show-plugin/output
+++ b/tests/Baseline/kafka.show-plugin/output
@@ -1,0 +1,8 @@
+Apache::Kafka - Writes logs to Kafka (dynamic, version 0.1)
+    [Writer] KafkaWriter (Log::WRITER_KAFKAWRITER)
+    [Constant] Kafka::kafka_conf
+    [Constant] Kafka::topic_name
+    [Constant] Kafka::max_wait_on_shutdown
+    [Constant] Kafka::tag_json
+    [Constant] Kafka::debug
+


### PR DESCRIPTION
This should turn this repo into a bro package containing a bro plugin.  It also fixes the unit tests, which were broken.  There is a follow-on JIRA to improve the unit tests and potentially integrate btests with travis.

# Testing
## Testing the plugin
1.  Spin up a centos 7 VM.
    ```
    vagrant init bento/centos-7.3
    vagrant up
    vagrant ssh
    sudo su -
    ```
1.  Install [Kafka 0.10.0.1](https://kafka.apache.org/0101/documentation.html#quickstart), [Zookeeper 3.4.6](https://zookeeper.apache.org/doc/r3.4.6/zookeeperStarted.html) (The same versions from [HDP 2.5.5](https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.5.5/bk_release-notes/content/ch01s01.html)), and any package dependancies for testing.
    ```
    cd
    yum -y install java screen
    wget https://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz{,.sha1}
    if [[ "$(sha1sum zookeeper-3.4.6.tar.gz)" == "$(cat zookeeper-3.4.6.tar.gz.sha1)" ]]; then tar -xvf zookeeper-3.4.6.tar.gz; else echo "sha1 sums do not match"; fi
    cd zookeeper-3.4.6
    cp conf/zoo_sample.cfg conf/zoo.cfg
    bin/zkServer.sh start
    cd
    wget https://mirrors.sonic.net/apache/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz
    wget https://dist.apache.org/repos/dist/release/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz.md5
    # Compare MD5s using md5sum
    tar -xvf kafka_2.10-0.10.0.1.tgz
    cd kafka_2.10-0.10.0.1
    bin/kafka-server-start.sh config/server.properties &
    bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic bro
    ```
1.  [Install bro 2.5.2](https://www.bro.org/sphinx/install/install.html) and [bro-pkg](http://bro-package-manager.readthedocs.io/en/stable/quickstart.html#installation).  Make sure you are running at least bro 2.5 and bro-pkg 1.2.0, and configure bro-pkg properly.
    ```
    # export PATH=$PATH:/usr/local/bro/bin
    # bro --version
    bro version 2.5.2
    # bro-pkg --version
    bro-pkg 1.2.2
    # bro-pkg autoconfig
    ```
1.  Create a working directory and pull in this PR (selfishly using my branch of `checkout-pr` from [metron-commit-stuff](https://github.com/jonzeolla/metron-commit-stuff/tree/support-bro-plugin) to test some recent updates)
    ```
    # git clone https://github.com/jonzeolla/metron-commit-stuff ~/metron-commit-stuff
    # cd ~/metron-commit-stuff
    # git checkout support-bro-plugin
    # cd
    # ~/metron-commit-stuff/checkout-pr 3
    Please select a repository:
      1) metron
      2) metron-bro-plugin-kafka
    Selection [metron]: bro
    <snip>
    ```
1.  Install the package, and all of its dependancies, from the PR branch.  Ensure it passes its unit tests.
    ```
    # Install librdkafka by following ONLY instruction 1 [here](https://github.com/apache/metron-bro-plugin-kafka#installation)
    cd ~/metron-bro-plugin-kafka-pr3/
    bro-pkg install .
    ```
1.  Configure the plugin.
    ```
    cat << EOF >> /usr/local/bro/share/bro/site/local.bro

    # Activate metron-bro-plugin-kafka
    @load metron-bro-plugin-kafka-pr3/Bro/Kafka

    # Configure metron-bro-plugin-kafka
    redef Kafka::logs_to_send = set(HTTP::LOG, DNS::LOG, Conn::LOG);
    EOF 
    ```
1.  Run bro manually while monitoring kafka to confirm things are working.
    ```
    mkdir -p ~/brotmp/nitroba ~/brotmp/example-traffic
    wget https://www.bro.org/static/traces/exercise-traffic.pcap -O ~/brotmp/example-traffic/exercise-traffic.pcap
    wget http://downloads.digitalcorpora.org/corpora/network-packet-dumps/2008-nitroba/nitroba.pcap -O ~/brotmp/nitroba/nitroba.pcap
    export PATH=$PATH:~/kafka_2.11-0.10.1.0/bin
    screen
    kafka-console-consumer.sh --zookeeper localhost:2181 --topic bro
    # Ctrl+A c to make a new screen window
    cd ~/brotmp/example-traffic
    bro -r exercise-traffic.pcap /usr/local/bro/share/bro/site/local.bro -C
    # Use Ctrl+A n to cycle through screen sessions for validation.  To run another test, on your second window, do
    cd ~/brotmp/nitroba
    bro -r nitroba.pcap /usr/local/bro/share/bro/site/local.bro -C
    ```

## Testing full-dev

Since full-dev naively uses this repo's master (in the future, once we make a [bro package release](http://bro-package-manager.readthedocs.io/en/stable/package.html#package-versioning), we should pin to a version), we should make sure it will work after this change is applied.  My instructions (for example, the `sed` commands) assume that you're doing this work on a mac.

1.  Spin up full-dev, including sensors, and repoint the metron-bro-plugin-kafka branch it clones to this PR.
    ```
    git clone https://github.com/apache/metron
    cd metron
    sed -i '' "s/ansibleSkipTags=.*/ansibleSkipTags=\'quick_dev\'/" metron-deployment/vagrant/full-dev-platform/Vagrantfile
    sed -i '' "s/version:.*/version: pr-3/" metron-deployment/roles/bro/tasks/metron-bro-plugin-kafka.yml
    # Make sure to copy and send the next 3 lines at once, assuming you're running this on a mac.
    sed -i '' "/dest: \/tmp\/metron-bro-plugin-kafka/a\ 
    \ \ \ \ refspec: +refs\/pull\/3\/head:pr-3
    " metron-deployment/roles/bro/tasks/metron-bro-plugin-kafka.yml
    cd metron-deployment/vagrant/full-dev-platform/
    vagrant up
    ```
1.  Set up the environment in full-dev.
    ```
    vagrant ssh
    sudo su -
    export PATH=$PATH:/usr/local/bro/bin
    service monit stop && service sensor-stubs stop bro && broctl stop
    ```
1.  Run bro against some public pcaps.
    ```
    mkdir -p ~/brotmp/nitroba ~/brotmp/example-traffic
    wget https://www.bro.org/static/traces/exercise-traffic.pcap -O ~/brotmp/example-traffic/exercise-traffic.pcap
    wget http://downloads.digitalcorpora.org/corpora/network-packet-dumps/2008-nitroba/nitroba.pcap -O ~/brotmp/nitroba/nitroba.pcap
    cd ~/brotmp/example-traffic
    bro -r exercise-traffic.pcap /usr/local/bro/share/bro/site/local.bro -C
    cd ~/brotmp/nitroba
    bro -r nitroba.pcap /usr/local/bro/share/bro/site/local.bro -C
    ```
1.  Verify that logs from the manually run pcaps (**not the sensor-stubs**) are properly getting to the bro kafka topic and/or into Kibana.
    - Note, that if you look in the Kibana UI for the non sensor-stub logs, you will need to change your view to be ~now-10y.