### PR TITLE
METRON-1407: Metron-Bro-Kafka plugin unable to find correct libkafka library.

### DIFF
--- a/cmake/FindLibRDKafka.cmake
+++ b/cmake/FindLibRDKafka.cmake
@@ -27,7 +27,7 @@ find_library(LibRDKafka_LIBRARIES
 
 find_library(LibRDKafka_C_LIBRARIES
     NAMES rdkafka
-    HINTS ${LibRDKafka_ROT_DIR}/lib
+    HINTS ${LibRDKafka_ROOT_DIR}/lib
     PATH_SUFFIXES ${CMAKE_LIBRARY_ARCHITECTURE}
 )
 


### PR DESCRIPTION
find_library was failing. I found this typo, and it solved my issue. 