### PR TITLE
METRON-1818: Remove config_files from bro-pkg.meta

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -5,7 +5,6 @@ script_dir = build/scripts/Apache/Kafka
 build_command = ./configure --bro-dist=%(bro_dist)s --with-librdkafka=%(LIBRDKAFKA_ROOT)s && make
 test_command = ( cd tests && btest -d )
 plugin_dir = build
-config_files = scripts/init.bro
 version = 0.2
 depends =
   bro >=2.5.0


### PR DESCRIPTION
Remove the `config_files` line from `bro-pkg.meta`, as it is [not necessary](https://bro-package-manager.readthedocs.io/en/stable/package.html?highlight=bro-pkg.meta#config-files-field) based on the fact our script primarily focuses on having the user redef a variable, as opposed to changing the scripts we provide themselves.