### PR TITLE
METRON-1817: Remove plugin dependency on zeek_dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ These instructions could also be helpful if you were interested in distributing 
 1. Build the plugin using the following commands.
 
     ```
-    $ ./configure --zeek-dist=$zeek_dist --with-librdkafka=$librdkafka_root
+    $ ./configure --with-librdkafka=$librdkafka_root
     $ make
     $ sudo make install
     ```

--- a/zkg.meta
+++ b/zkg.meta
@@ -2,7 +2,7 @@
 description = A Zeek log writer plugin that sends logging output to Kafka.
 tags = log writer, zeek plugin, kafka
 script_dir = build/scripts/Apache/Kafka
-build_command = ./configure --zeek-dist=%(zeek_dist)s --with-librdkafka=%(LIBRDKAFKA_ROOT)s && make
+build_command = ./configure --with-librdkafka=%(LIBRDKAFKA_ROOT)s && make
 test_command = ( cd tests && btest -d )
 plugin_dir = build
 version = 0.3.0


### PR DESCRIPTION
This is in response to [this](https://github.com/zeek/zeek/blob/156686b2376253c73a19c76f952eb4c2ad7c6fbd/NEWS#L1285-L1289)

## TODO
 * [X] Test end to end