### PR TITLE
METRON-1828: Improve bro plugin contributing documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Pull Request Checklist
 
-Thank you for submitting a contribution to Apache Metron's kafka log writing plugin for Bro.
+Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.
 
 In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:
 
@@ -18,7 +18,7 @@ In order to streamline the review of the contribution we ask you follow these gu
 - [ ] Have you included steps or a guide to how the change may be verified and tested manually?
 - [ ] Have you ensured that the full suite of tests and checks have been executed via:
   ```
-  bro-pkg install $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
+  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
   ```
 - [ ] Have you written or updated unit tests and or integration tests to verify your changes?
 - [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Contributor Comments
+[Please place any comments here.  A description of the problem/enhancement, how to reproduce the issue, your testing methodology, etc.]
+
+
+## Pull Request Checklist
+
+Thank you for submitting a contribution to Apache Metron's kafka log writing plugin for Bro.
+
+In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:
+
+### For all changes:
+- [ ] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
+- [ ] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
+- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?
+
+### For code changes:
+- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
+- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
+- [ ] Have you ensured that the full suite of tests and checks have been executed via:
+  ```
+  bro-pkg install $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
+  ```
+- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
+- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
+- [ ] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?
+

--- a/README.md
+++ b/README.md
@@ -266,5 +266,5 @@ redef Kafka::kafka_conf = table( ["metadata.broker.list"] = "node1:6667"
 
 ## Contributing
 
-If you are interested in contributing to this plugin, please see the upstream [CONTRIBUTING.md](https://github.com/apache/metron/blob/master/CONTRIBUTING.md).
+If you are interested in contributing to this plugin, please see the Apache Metron [CONTRIBUTING.md](https://github.com/apache/metron/blob/master/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This software is a part of the [Apache Metron](http://metron.apache.org/) projec
 * [Activation](#activation)
 * [Settings](#settings)
 * [Kerberos](#kerberos)
+* [Contributing](#contributing)
 
 ## Installation
 
@@ -262,3 +263,8 @@ redef Kafka::kafka_conf = table( ["metadata.broker.list"] = "node1:6667"
                                , ["sasl.kerberos.principal"] = "metron@EXAMPLE.COM"
                                );
 ```
+
+## Contributing
+
+If you are interested in contributing to this plugin, please see the upstream [CONTRIBUTING.md](https://github.com/apache/metron/blob/master/CONTRIBUTING.md).
+


### PR DESCRIPTION
This should add a PR template, and a section to the README that points to the upstream Apache Metron CONTRIBUTING.md.