### PR TITLE
METRON-1862: Cant Load Metron Bro Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This software is a part of the [Apache Metron](http://metron.apache.org/) projec
 1. Build the plugin using the following commands.
 
     ```
+    ##$BRO_SRC should be the path of the BRO source directory you would have downloaded
     ./configure --bro-dist=$BRO_SRC
     make
     sudo make install
@@ -50,7 +51,7 @@ The goal in this example is to send all HTTP and DNS records to a Kafka topic na
  * By defining `topic_name` all records will be sent to the same Kafka topic.
  * Defining `logs_to_send` will ensure that only HTTP and DNS records are sent. 
 ```
-@load packages/metron-bro-plugin-kafka/Apache/Kafka
+@load packages/metron-bro-plugin-kafka/scripts/Apache/Kafka
 redef Kafka::logs_to_send = set(HTTP::LOG, DNS::LOG);
 redef Kafka::topic_name = "bro";
 redef Kafka::kafka_conf = table(
@@ -67,7 +68,7 @@ It is also possible to send each log stream to a uniquely named topic.  The goal
  * Each log writer accepts a separate configuration table.
 
 ```
-@load packages/metron-bro-plugin-kafka/Apache/Kafka
+@load packages/metron-bro-plugin-kafka/scripts/Apache/Kafka
 redef Kafka::topic_name = "";
 redef Kafka::tag_json = T;
 
@@ -105,7 +106,7 @@ You may want to configure bro to filter log messages with certain characteristic
  * If the log message contains a 128 byte long source or destination IP address, the log is not sent to kafka.
 
 ```
-@load packages/metron-bro-plugin-kafka/Apache/Kafka
+@load packages/metron-bro-plugin-kafka/scripts/Apache/Kafka
 redef Kafka::topic_name = "bro";
 redef Kafka::tag_json = T;
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The goal in this example is to send all HTTP and DNS records to a Kafka topic na
  * By defining `topic_name` all records will be sent to the same Kafka topic.
  * Defining `logs_to_send` will ensure that only HTTP and DNS records are sent. 
 ```
-@load packages/metron-bro-plugin-kafka/scripts/Apache/Kafka
+@load 'PathToDirContainingTheDownloadedMetronPlugin'/metron-bro-plugin-kafka/scripts/Apache/Kafka
 redef Kafka::logs_to_send = set(HTTP::LOG, DNS::LOG);
 redef Kafka::topic_name = "bro";
 redef Kafka::kafka_conf = table(
@@ -68,7 +68,7 @@ It is also possible to send each log stream to a uniquely named topic.  The goal
  * Each log writer accepts a separate configuration table.
 
 ```
-@load packages/metron-bro-plugin-kafka/scripts/Apache/Kafka
+@load 'PathToDirContainingTheDownloadedMetronPlugin'/metron-bro-plugin-kafka/scripts/Apache/Kafka
 redef Kafka::topic_name = "";
 redef Kafka::tag_json = T;
 
@@ -106,7 +106,7 @@ You may want to configure bro to filter log messages with certain characteristic
  * If the log message contains a 128 byte long source or destination IP address, the log is not sent to kafka.
 
 ```
-@load packages/metron-bro-plugin-kafka/scripts/Apache/Kafka
+@load 'PathToDirContainingTheDownloadedMetronPlugin'/metron-bro-plugin-kafka/scripts/Apache/Kafka
 redef Kafka::topic_name = "bro";
 redef Kafka::tag_json = T;
 


### PR DESCRIPTION
## Contributor Comments
The previous Load path was "@load packages/metron-bro-plugin-kafka/Apache/Kafka".
However, in the new version the path to load the metron bro plugin is 
"packages/metron-bro-plugin-kafka/scripts/Apache/Kafka"

When I loaded the plugin from the old path that is "packages/metron-bro-plugin-kafka/Apache/Kafka" I received the following error when running 'broctl deploy' : 
can't find packages/metron-bro-plugin-kafka/Apache/Kafka

Therefore to correctly load the plugin, ensure your load path is correct like this:
@load 'PathToDirContainingTheDownloadedMetronPlugin'/metron-bro-plugin-kafka/scripts/Apache/Kafka


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?

