### PR TITLE
METRON-1865: Fix metron-bro-plugin-kafka tests

### DIFF
--- a/tests/Baseline/kafka.show-plugin/output
+++ b/tests/Baseline/kafka.show-plugin/output
@@ -4,5 +4,6 @@ Apache::Kafka - Writes logs to Kafka (dynamic, version 0.3)
     [Constant] Kafka::topic_name
     [Constant] Kafka::max_wait_on_shutdown
     [Constant] Kafka::tag_json
+    [Constant] Kafka::json_timestamps
     [Constant] Kafka::debug
 


### PR DESCRIPTION
## Contributor Comments
This fixes the btests which were unintentionally broken as a part of apache/metron-bro-plugin-kafka#6.

An easy way to test this is to use `bro-pkg` to install the plugin (which runs all of the tests by default), or you can go on a properly configured box (wrt `btest`) and run `cd metron-bro-plugin-kafka/tests/ && btest -d`.