### PR TITLE
METRON-1991: Bro plugin docker scripts should exit nonzero when bro and kafka counts differ

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -61,6 +61,7 @@ testing scripts to be added to a pull request, and subsequently to a test suite.
 #### Scripts executed on the host to setup and interact with the docker containers
 
 ```bash
+├── analyze_results.sh
 ├── build_container.sh
 ├── cleanup_docker.sh
 ├── create_docker_network.sh
@@ -83,6 +84,11 @@ testing scripts to be added to a pull request, and subsequently to a test suite.
 └── stop_container.sh
 ```
 
+- `analyze_results.sh`: Analyzes the `results.csv` files for any issues
+  ###### Parameters
+  ```bash
+  --test-directory               [REQUIRED] The directory for the tests
+  ```
 - `build_container.sh`: Runs docker build in the passed directory, and names the results
   ###### Parameters
   ```bash
@@ -191,12 +197,12 @@ testing scripts to be added to a pull request, and subsequently to a test suite.
   ```bash
   --data-path                    [REQUIRED] The pcap data path
   ```
-- `print_results.sh` : Prints the `results.csv` for all the pcaps processed in the given directory to console
+- `print_results.sh`: Prints the `results.csv` for all the pcaps processed in the given directory to console
   ###### Parameters
   ```bash
   --test-directory               [REQUIRED] The directory for the tests
   ```
-- `split_kafka_output_by_log.sh` : For a pcap result directory, will create a LOG.kafka.log for each LOG.log's entry in the kafka-output.log
+- `split_kafka_output_by_log.sh`: For a pcap result directory, will create a LOG.kafka.log for each LOG.log's entry in the kafka-output.log
   ###### Parameters
   ```bash
   --log-directory                [REQUIRED] The directory with the logs

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -202,6 +202,12 @@ rc=$?; if [[ ${rc} != 0 ]]; then
   exit ${rc}
 fi
 
+"${SCRIPT_DIR}"/analyze_results.sh --test-directory="${TEST_OUTPUT_PATH}"
+rc=$?; if [[ ${rc} != 0 ]]; then
+  echo "ERROR> ISSUE ENCOUNTERED WHEN ANALYZING RESULTS"
+  exit ${rc}
+fi
+
 echo ""
 echo "Run complete"
 echo "The kafka and bro output can be found at ${TEST_OUTPUT_PATH}"

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -179,22 +179,28 @@ do
   echo "OFFSET------------------> ${OFFSET}"
 
   bash "${SCRIPT_DIR}"/docker_execute_process_data_file.sh --pcap-file-name="${BASE_FILE_NAME}" --output-directory-name="${DOCKER_DIRECTORY_NAME}"
-
   rc=$?; if [[ ${rc} != 0 ]]; then
     echo "ERROR> FAILED TO PROCESS ${file} DATA.  CHECK LOGS, please run the finish_end_to_end.sh when you are done."
     exit ${rc}
   fi
+
   KAFKA_OUTPUT_FILE="${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}/kafka-output.log"
   bash "${SCRIPT_DIR}"/docker_run_consume_bro_kafka.sh --offset=$OFFSET | "${ROOT_DIR}"/remove_timeout_message.sh | tee "${KAFKA_OUTPUT_FILE}"
-
   rc=$?; if [[ ${rc} != 0 ]]; then
     echo "ERROR> FAILED TO PROCESS ${DATA_PATH} DATA.  CHECK LOGS"
   fi
 
   "${SCRIPT_DIR}"/split_kakfa_output_by_log.sh --log-directory="${TEST_OUTPUT_PATH}/${DOCKER_DIRECTORY_NAME}"
+  rc=$?; if [[ ${rc} != 0 ]]; then
+    echo "ERROR> ISSUE ENCOUNTERED WHEN SPLITTING KAFKA OUTPUT LOGS"
+  fi
 done
 
 "${SCRIPT_DIR}"/print_results.sh --test-directory="${TEST_OUTPUT_PATH}"
+rc=$?; if [[ ${rc} != 0 ]]; then
+  echo "ERROR> ISSUE ENCOUNTERED WHEN PRINTING RESULTS"
+  exit ${rc}
+fi
 
 echo ""
 echo "Run complete"

--- a/docker/scripts/analyze_results.sh
+++ b/docker/scripts/analyze_results.sh
@@ -170,9 +170,9 @@ function print_log_comparison_insights
   # For example, if count_occurrences_of_each_log_file identified that there
   # were 10 instances of http logs across all of the `results.csv` files,
   # ${LOG_OCCURRENCE[http]} should equal 10. If check_for_unequal_log_counts
-  # also found 10 instances where the http bro and kafka log counts were
-  # imbalanced, ${UNIQ_UNEQUAL_RESULTS[http]} would also have 10 entries,
-  # causing us to warn the user of that insight.
+  # independently found 10 instances where the http bro and kafka log counts
+  # from the `results.csv` files were not equal, ${UNIQ_UNEQUAL_RESULTS[http]}
+  # would also have 10 entries, causing us to warn the user of that insight.
   for KEY in "${!UNIQ_UNEQUAL_RESULTS[@]}"; do
     if [[ "${UNIQ_UNEQUAL_RESULTS[${KEY}]}" == "${LOG_OCCURRENCE[${KEY}]}" ]]; then
       _echo WARN "None of the ${KEY} log counts were the same between bro and kafka."

--- a/docker/scripts/analyze_results.sh
+++ b/docker/scripts/analyze_results.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+shopt -s nocasematch
+#set -u # nounset disabled
+set -e # errexit
+set -E # errtrap
+set -o pipefail
+
+#
+# Analyzes the results.csv files to identify issues
+#
+
+function help {
+  echo " "
+  echo "usage: ${0}"
+  echo "    --test-directory           [REQUIRED] The directory for the tests"
+  echo "    -h/--help                  Usage information."
+  echo " "
+  echo " "
+}
+
+SCRIPT_NAME=$(basename -- "$0")
+TEST_DIRECTORY=
+declare -A UNEQUAL_RESULTS
+declare -a LOG_NAMES
+declare -A LOG_OCCURRENCE
+declare -A UNIQ_UNEQUAL_RESULTS
+declare -r txtDEFAULT='\033[0m'
+# shellcheck disable=SC2034
+declare -r txtERROR='\033[0;31m'
+# shellcheck disable=SC2034
+declare -r txtWARN='\033[0;33m'
+
+# Handle command line options
+for i in "$@"; do
+  case $i in
+  #
+  # TEST_DIRECTORY
+  #
+  #   --test-directory
+  #
+    --test-directory=*)
+      TEST_DIRECTORY="${i#*=}"
+      shift # past argument=value
+    ;;
+
+  #
+  # -h/--help
+  #
+    -h | --help)
+      help
+      exit 0
+      shift # past argument with no value
+    ;;
+
+  #
+  # Unknown option
+  #
+    *)
+      UNKNOWN_OPTION="${i#*=}"
+      _echo ERROR "unknown option: $UNKNOWN_OPTION"
+      help
+    ;;
+  esac
+done
+
+if [[ -z "$TEST_DIRECTORY" ]]; then
+  echo "$TEST_DIRECTORY must be passed"
+  exit 1
+fi
+
+echo "Running ${SCRIPT_NAME} with"
+echo "TEST_DIRECTORY = $TEST_DIRECTORY"
+echo "==================================================="
+
+## Main functions
+function _echo() {
+  color="txt${1:-DEFAULT}"
+  case "${1}" in
+    ERROR)
+      >&2 echo -e "${!color}${1}> ${2}${txtDEFAULT}"
+      ;;
+    WARN)
+      echo -e "${!color}${1}> ${2}${txtDEFAULT}"
+      ;;
+    *)
+      echo -e "${!color}${1}> ${2}${txtDEFAULT}"
+      ;;
+  esac
+}
+
+function count_occurrences_of_each_log_file
+{
+  # Count the number of occurences of each log name
+  for LOG_NAME in "${LOG_NAMES[@]}"; do
+    (( ++LOG_OCCURRENCE["${LOG_NAME}"] ))
+  done
+}
+
+function check_for_unequal_log_counts
+{
+  RESULTS_FILE="${1}"
+
+  # Get the pcap folder name from the provided file
+  # shellcheck disable=SC2001
+  PCAP_FOLDER="$( cd "$( dirname "${RESULTS_FILE}" )" >/dev/null 2>&1 && echo "${PWD##*/}")"
+
+  # Check each log line in the provided log file for unequal results
+  for LOG_NAME in "${LOG_NAMES[@]}"; do
+    # For each log in the provided results, identify any unequal log counts
+    UNEQUAL_LOG=$(awk -F\, -v log_name="${LOG_NAME}" '$1 == log_name && $2 != $3 {print $1}' "${RESULTS_FILE}")
+
+    # Create a space separated list of unequal logs to simulate a
+    # multidimensional array
+    if [[ -n "${UNEQUAL_LOG}" ]]; then
+      if [[ "${#UNEQUAL_RESULTS[${PCAP_FOLDER}]}" -eq 0 ]]; then
+        UNEQUAL_RESULTS["${PCAP_FOLDER}"]="${UNEQUAL_LOG}"
+      else
+        UNEQUAL_RESULTS["${PCAP_FOLDER}"]+=" ${UNEQUAL_LOG}"
+      fi
+    fi
+  done
+}
+
+function print_unequal_results
+{
+  # Output a table with the pcap file and log name details where the imbalance
+  # was detected
+  {
+  echo "PCAP FOLDER,LOG NAME"
+
+  for KEY in "${!UNEQUAL_RESULTS[@]}"; do
+    # This must be done because we are simulating multidimensional arrays due to
+    # the lack of native bash support
+    for VALUE in ${UNEQUAL_RESULTS[${KEY}]}; do
+      echo "${KEY},${VALUE}"
+    done
+  done
+  } | column -t -s ','
+}
+
+function print_log_comparison_insights
+{
+  # Load the log to instance count mapping from UNEQUAL_RESULTS into a new
+  # associative array
+  # shellcheck disable=SC2046
+  declare -A $(echo "${UNEQUAL_RESULTS[@]}" | tr ' ' '\n' | sort | uniq -c | awk '{print "UNIQ_UNEQUAL_RESULTS["$2"]="$1}')
+
+  # Compare each log type's number of issues to the number of instances.  If
+  # they are equal, this indicates that there may be an issue specific to that
+  # log.
+  for KEY in "${!UNIQ_UNEQUAL_RESULTS[@]}"; do
+    if [[ "${UNIQ_UNEQUAL_RESULTS[${KEY}]}" == "${LOG_OCCURRENCE[${KEY}]}" ]]; then
+      _echo WARN "None of the ${KEY} log counts were the same between bro and kafka."
+    fi
+  done
+}
+
+## Main
+# Move over to the docker area
+cd "${TEST_DIRECTORY}" || exit 1
+# Get a list of results files
+RESULTS_FILES=$(find "${TEST_DIRECTORY}" -name "results.csv")
+# Analyze each results file for issues
+for file in $RESULTS_FILES; do
+  # Capture the first column (the log names) of the provided file's contents in
+  # the array LOG_NAMES, excluding the header
+  mapfile -s 1 -t LOG_NAMES < <(awk -F\, '{print $1}' "${file}")
+
+  count_occurrences_of_each_log_file
+  check_for_unequal_log_counts "${file}"
+done
+
+if [[ "${#UNEQUAL_RESULTS[@]}" -gt 0 ]]; then
+  _echo ERROR "UNEQUALITY FOUND IN BRO AND KAFKA LOG COUNTS"
+  echo ""
+
+  print_unequal_results
+  print_log_comparison_insights
+
+  exit 1
+fi
+

--- a/docker/scripts/analyze_results.sh
+++ b/docker/scripts/analyze_results.sh
@@ -36,6 +36,21 @@ function help {
   echo " "
 }
 
+function _echo() {
+  color="txt${1:-DEFAULT}"
+  case "${1}" in
+    ERROR)
+      >&2 echo -e "${!color}${1}> ${2}${txtDEFAULT}"
+      ;;
+    WARN)
+      echo -e "${!color}${1}> ${2}${txtDEFAULT}"
+      ;;
+    *)
+      echo -e "${!color}${1}> ${2}${txtDEFAULT}"
+      ;;
+  esac
+}
+
 SCRIPT_NAME=$(basename -- "$0")
 TEST_DIRECTORY=
 declare -A LOGS_WITH_UNEQUAL_RESULTS
@@ -91,21 +106,6 @@ echo "TEST_DIRECTORY = $TEST_DIRECTORY"
 echo "==================================================="
 
 ## Main functions
-function _echo() {
-  color="txt${1:-DEFAULT}"
-  case "${1}" in
-    ERROR)
-      >&2 echo -e "${!color}${1}> ${2}${txtDEFAULT}"
-      ;;
-    WARN)
-      echo -e "${!color}${1}> ${2}${txtDEFAULT}"
-      ;;
-    *)
-      echo -e "${!color}${1}> ${2}${txtDEFAULT}"
-      ;;
-  esac
-}
-
 function count_occurrences_of_each_log_file
 {
   # Count the number of occurences of each log name

--- a/docker/scripts/analyze_results.sh
+++ b/docker/scripts/analyze_results.sh
@@ -189,7 +189,7 @@ for file in $RESULTS_FILES; do
 done
 
 if [[ "${#UNEQUAL_RESULTS[@]}" -gt 0 ]]; then
-  _echo ERROR "UNEQUALITY FOUND IN BRO AND KAFKA LOG COUNTS"
+  _echo ERROR "INEQUALITY FOUND IN BRO AND KAFKA LOG COUNTS"
   echo ""
 
   print_unequal_results

--- a/docker/scripts/analyze_results.sh
+++ b/docker/scripts/analyze_results.sh
@@ -163,9 +163,16 @@ function print_log_comparison_insights
   # shellcheck disable=SC2046
   declare -A $(echo "${UNEQUAL_RESULTS[@]}" | tr ' ' '\n' | sort | uniq -c | awk '{print "UNIQ_UNEQUAL_RESULTS["$2"]="$1}')
 
-  # Compare each log type's number of issues to the number of instances.  If
-  # they are equal, this indicates that there may be an issue specific to that
-  # log.
+  # Compare each log type's instances of inequality to the total number of
+  # instances of each log.  If they are equal, this indicates that there may be
+  # a log-type related issue.
+  #
+  # For example, if count_occurrences_of_each_log_file identified that there
+  # were 10 instances of http logs across all of the `results.csv` files,
+  # ${LOG_OCCURRENCE[http]} should equal 10. If check_for_unequal_log_counts
+  # also found 10 instances where the http bro and kafka log counts were
+  # imbalanced, ${UNIQ_UNEQUAL_RESULTS[http]} would also have 10 entries,
+  # causing us to warn the user of that insight.
   for KEY in "${!UNIQ_UNEQUAL_RESULTS[@]}"; do
     if [[ "${UNIQ_UNEQUAL_RESULTS[${KEY}]}" == "${LOG_OCCURRENCE[${KEY}]}" ]]; then
       _echo WARN "None of the ${KEY} log counts were the same between bro and kafka."

--- a/docker/scripts/analyze_results.sh
+++ b/docker/scripts/analyze_results.sh
@@ -175,7 +175,7 @@ function print_log_comparison_insights
   # would also have 10 entries, causing us to warn the user of that insight.
   for KEY in "${!LOG_ISSUE_COUNT[@]}"; do
     if [[ "${LOG_ISSUE_COUNT[${KEY}]}" == "${OVERALL_LOG_CARDINALITY[${KEY}]}" ]]; then
-      _echo WARN "None of the ${KEY} log counts were the same between bro and kafka."
+      _echo WARN "None of the ${KEY} log counts were the same between bro and kafka.  This may indicate an issue specific to that log."
     fi
   done
 }

--- a/docker/scripts/build_container.sh
+++ b/docker/scripts/build_container.sh
@@ -22,6 +22,7 @@ set -u # nounset
 set -e # errexit
 set -E # errtrap
 set -o pipefail
+
 #
 # Runs docker build in a provided directory, with a provided name
 #
@@ -36,6 +37,7 @@ function help {
   echo " "
 }
 
+SCRIPT_NAME=$(basename -- "$0")
 CONTAINER_DIRECTORY=
 CONTAINER_NAME=
 
@@ -92,7 +94,7 @@ if [[ -z "$CONTAINER_NAME" ]]; then
   exit 1
 fi
 
-echo "Running with "
+echo "Running ${SCRIPT_NAME} with"
 echo "CONTAINER_DIRECTORY = $CONTAINER_DIRECTORY"
 echo "CONTAINER_NAME = $CONTAINER_NAME"
 echo "==================================================="

--- a/docker/scripts/print_results.sh
+++ b/docker/scripts/print_results.sh
@@ -31,11 +31,12 @@ function help {
   echo " "
   echo "usage: ${0}"
   echo "    --test-directory           [REQUIRED] The directory for the tests"
-  echo "    -h/--help                   Usage information."
+  echo "    -h/--help                  Usage information."
   echo " "
   echo " "
 }
 
+SCRIPT_NAME=$(basename -- "$0")
 TEST_DIRECTORY=
 
 # Handle command line options
@@ -77,17 +78,15 @@ if [[ -z "$TEST_DIRECTORY" ]]; then
 fi
 
 
-echo "Running with "
+echo "Running ${SCRIPT_NAME} with"
 echo "TEST_DIRECTORY = $TEST_DIRECTORY"
 echo "==================================================="
 
 # Move over to the docker area
 cd "${TEST_DIRECTORY}" || exit 1
-RESULTS_FILES=$(find "${TEST_DIRECTORY}" -name "results.csv")
-for file in $RESULTS_FILES; do
-  echo "-->" "${file}"
-  column -t -s ',' "$file"
-  echo -e "========================================================\n"
-  awk -F\, 'FNR > 1 && $2 != $3 {print "ERROR> The " $1 " bro and kafka log counts do not match for " FILENAME; exit 1}' "${file}"
-done
+find "${TEST_DIRECTORY}" -name "results.csv" \
+  -exec echo "-->" '{}' \; \
+  -exec column -t -s ',' '{}' \; \
+  -exec echo "========================================================" \; \
+  -exec echo "" \;
 

--- a/docker/scripts/print_results.sh
+++ b/docker/scripts/print_results.sh
@@ -86,12 +86,8 @@ cd "${TEST_DIRECTORY}" || exit 1
 RESULTS_FILES=$(find "${TEST_DIRECTORY}" -name "results.csv")
 for file in $RESULTS_FILES; do
   echo "-->" "${file}"
-  cat "${file}" | sed 1d | awk -F\, '$2 != $3 {exit 1}'
-  rc=$?; if [[ ${rc} != 0 ]]; then
-    echo "ERROR> COUNTS DO NOT MATCH IN FILE ${file}"
-    exit ${rc}
-  fi
   column -t -s ',' "$file"
   echo -e "========================================================\n"
+  awk -F\, 'FNR > 1 && $2 != $3 {print "ERROR> The " $1 " bro and kafka log counts do not match for " FILENAME; exit 1}' "${file}"
 done
 

--- a/docker/scripts/print_results.sh
+++ b/docker/scripts/print_results.sh
@@ -83,9 +83,15 @@ echo "==================================================="
 
 # Move over to the docker area
 cd "${TEST_DIRECTORY}" || exit 1
-find "${TEST_DIRECTORY}" -name "results.csv" \
-  -exec echo "-->" '{}' \; \
-  -exec column -t -s ',' '{}' \; \
-  -exec echo "========================================================" \; \
-  -exec echo "" \;
+RESULTS_FILES=$(find "${TEST_DIRECTORY}" -name "results.csv")
+for file in $RESULTS_FILES; do
+  echo "-->" "${file}"
+  cat "${file}" | sed 1d | awk -F\, '$2 != $3 {exit 1}'
+  rc=$?; if [[ ${rc} != 0 ]]; then
+    echo "ERROR> COUNTS DO NOT MATCH IN FILE ${file}"
+    exit ${rc}
+  fi
+  column -t -s ',' "$file"
+  echo -e "========================================================\n"
+done
 

--- a/docker/scripts/split_kakfa_output_by_log.sh
+++ b/docker/scripts/split_kakfa_output_by_log.sh
@@ -37,6 +37,7 @@ function help {
   echo " "
 }
 
+SCRIPT_NAME=$(basename -- "$0")
 LOG_DIRECTORY=
 
 # Handle command line options
@@ -77,7 +78,7 @@ if [[ -z "$LOG_DIRECTORY" ]]; then
   exit 1
 fi
 
-echo "Running with "
+echo "Running ${SCRIPT_NAME} with"
 echo "$LOG_DIRECTORY = $LOG_DIRECTORY"
 echo "==================================================="
 


### PR DESCRIPTION
## Contributor Comments
When the bro and kafka counts differ, that indicates an issue and the script should exit nonzero.  This approach will also allow us to use `./run_end_to_end.sh` in travis ([METRON-1305](https://issues.apache.org/jira/browse/METRON-1305?filter=-1)).

### Testing
I reintroduced a prior bug (bfc9cbbdc97c3a12c59e9d9786bd7e3996a196f5) and then ran `./run_end_to_end.sh` and it failed.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [X] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [X] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [X] Have you included steps or a guide to how the change may be verified and tested manually?
- [X] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?