### PR TITLE
METRON-2017: The Bro plugin docker data processing script incorrectly runs bro

### DIFF
--- a/docker/in_docker_scripts/process_data_file.sh
+++ b/docker/in_docker_scripts/process_data_file.sh
@@ -74,7 +74,7 @@ if [ ! -d /root/data ]; then
   exit 1
 fi
 cd /root/test_output/"${OUTPUT_DIRECTORY_NAME}" || exit 1
-find /root/data -type f -name "${PCAP_FILE_NAME}" -print0 | xargs -0 bro -r {} /usr/local/bro/share/bro/site/local.bro -C
+find /root/data -type f -name "${PCAP_FILE_NAME}" -print0 | xargs -0 bro /usr/local/bro/share/bro/site/local.bro -C -r
 rc=$?; if [[ ${rc} != 0 ]]; then
   exit ${rc}
 fi


### PR DESCRIPTION
## Contributor Comments
In METRON-1990, the `process_data_file.sh` script was modified to use `xargs` instead of `find -exec` in order to exit nonzero when `bro` encountered failures when parsing the provided pcap files. In some cases, this is causing a parsing error because the `xargs` command is providing the output of the find command to `bro` twice (as shown below).  This is the effective command being run after removing the find and xargs:
```
[root@7fb8a51d00ba exercise-traffic_pcap]# bro -r /root/data/example-traffic/exercise-traffic.pcap /usr/local/bro/share/bro/site/local.bro -C /root/data/example-traffic/exercise-traffic.pcap
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character - �
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unrecognized character -
error in /root/data/example-traffic/exercise-traffic.pcap, line 1: unknown identifier K, at or near "K"
```

The fix is to simplify the command and allow the pcap to be provided solely at the end of the bro call.

### Testing
In order to test this, use the [apache/metron](https://github.com/apache/metron) `dev-utilities/committer-utils/prepare-commit` script to create a clean working area, and run `./run_end_to_end.sh`.


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [ ] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?

