### PR TITLE
METRON-2021 add screen and configuration to image

### DIFF
--- a/docker/containers/bro-localbuild-container/.screenrc
+++ b/docker/containers/bro-localbuild-container/.screenrc
@@ -1,0 +1,22 @@
+# terminfo and termcap for nice 256 color terminal
+# allow bold colors - necessary for some reason
+attrcolor b ".I"
+# tell screen how to set colors. AB = background, AF=foreground
+termcapinfo xterm 'Co#256:AB=\E[48;5;%dm:AF=\E[38;5;%dm'
+# erase background with current bg color
+defbce "on"
+
+# the status at the bottom of the window
+hardstatus alwayslastline
+hardstatus string '%{gk}[ %{G}%H %{g}][%S][%= %{wk}%?%-Lw%?%{=b kR}(%{W}%n*%f %t%?(%u)%?%{=b kR})%{= kw}%?%+Lw%?%?%= %{g}][%{Y}%l%{g}]%{=b C}[ %m/%d %c ]%{W}'
+
+#turn off the startup banner
+startup_message off
+
+#i want to see all screen messages for a longer time
+msgwait 86400
+
+
+
+
+

--- a/docker/containers/bro-localbuild-container/.screenrc
+++ b/docker/containers/bro-localbuild-container/.screenrc
@@ -1,8 +1,10 @@
 # terminfo and termcap for nice 256 color terminal
 # allow bold colors - necessary for some reason
 attrcolor b ".I"
+
 # tell screen how to set colors. AB = background, AF=foreground
 termcapinfo xterm 'Co#256:AB=\E[48;5;%dm:AF=\E[38;5;%dm'
+
 # erase background with current bg color
 defbce "on"
 
@@ -16,7 +18,5 @@ startup_message off
 #i want to see all screen messages for a longer time
 msgwait 86400
 
-
-
-
-
+# Set scrollback to 20k
+defscrollback 20000

--- a/docker/containers/bro-localbuild-container/Dockerfile
+++ b/docker/containers/bro-localbuild-container/Dockerfile
@@ -18,8 +18,16 @@ FROM centos:7
 WORKDIR /root
 
 # install development tools
-RUN yum -y groupinstall "Development Tools"
-RUN yum -y install cmake make gcc gcc-c++ flex bison libpcap libpcap-devel openssl-devel python-devel swig zlib-devel perl cyrus-sasl cyrus-sasl-devel cyrus-sasl-gssapi git jq
+RUN yum -y groupinstall "Development Tools" && \
+   yum -y install cmake make gcc gcc-c++ \
+   flex bison libpcap libpcap-devel \
+   openssl-devel python-devel swig \
+   zlib-devel perl \
+   cyrus-sasl cyrus-sasl-devel cyrus-sasl-gssapi \
+   git jq screen
+
+# copy in the screen -rc
+COPY .screenrc /root
 
 # install bro
 RUN curl -L https://www.bro.org/downloads/bro-2.5.5.tar.gz | tar xvz


### PR DESCRIPTION
## testing

`./run_end_to_end.sh && scripts/docker_execute_shell.sh`
` screen`
`ctrl-a ctrl-d`
`exit`
`exit`
`scripts/docker_execute_shell.sh`
`screen -r`


You can also test just the screenrc without docker by going to the directory
and running `screen -c .screenrc


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [-] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [-] Have you written or updated unit tests and or integration tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [-] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?
