### PR TITLE
METRON-2269 - handle when run from non-git repository

### DIFF
--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -19,7 +19,6 @@
 
 shopt -s nocasematch
 set -u # nounset
-set -e # errexit
 set -E # errtrap
 set -o pipefail
 
@@ -55,7 +54,36 @@ DATE=$(date)
 LOG_DATE=${DATE// /_}
 TEST_OUTPUT_PATH="${ROOT_DIR}/test_output/"${LOG_DATE//:/_}
 KAFKA_TOPIC="bro"
-PLUGIN_VERSION=$(cd "${ROOT_DIR}" && git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+
+cd "${ROOT_DIR}" || { echo "NO ROOT" ; exit 1; }
+# we may not be checked out from git, check and make it so that we are since
+# bro-pkg requires it
+
+git status 2&>1
+rc=$?; if [[ ${rc} != 0 ]]; then
+  echo "bro-pkg requires the plugin to be a git repo, creating..."
+  git init .
+  rc=$?; if [[ ${rc} != 0 ]]; then
+    echo "ERROR> FAILED TO INITIALIZE GIT IN PLUGIN DIRECTORY. ${rc}"
+  exit ${rc}
+  fi
+  git add .
+  rc=$?; if [[ ${rc} != 0 ]]; then
+    echo "ERROR> FAILED TO ADD ALL TO GIT PLUGIN DIRECTORY. ${rc}"
+  exit ${rc}
+  fi
+  git commit -m 'docker run'
+  rc=$?; if [[ ${rc} != 0 ]]; then
+    echo "ERROR> FAILED TO COMMIT TO GIT MASTER IN PLUGIN DIRECTORY. ${rc}"
+  exit ${rc}
+  fi
+  echo "git repo created"
+fi
+
+# set errexit for the rest of the run
+set -e
+
+PLUGIN_VERSION=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 
 # Handle command line options
 for i in "$@"; do

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -47,6 +47,7 @@ fi
 SKIP_REBUILD_BRO=false
 NO_PCAP=false
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+PLUGIN_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. > /dev/null && pwd)"
 SCRIPT_DIR="${ROOT_DIR}"/scripts
 CONTAINER_DIR="${ROOT_DIR}"/containers/bro-localbuild-container
 DATA_PATH="${ROOT_DIR}"/data
@@ -55,7 +56,7 @@ LOG_DATE=${DATE// /_}
 TEST_OUTPUT_PATH="${ROOT_DIR}/test_output/"${LOG_DATE//:/_}
 KAFKA_TOPIC="bro"
 
-cd "${ROOT_DIR}" || { echo "NO ROOT" ; exit 1; }
+cd "${PLUGIN_ROOT_DIR}" || { echo "NO PLUGIN ROOT" ; exit 1; }
 # we may not be checked out from git, check and make it so that we are since
 # bro-pkg requires it
 
@@ -147,7 +148,7 @@ for i in "$@"; do
 done
 
 EXTRA_ARGS="$*"
-
+cd "${ROOT_DIR}" || { echo "NO ROOT" ; exit 1; }
 echo "Running build_container with "
 echo "SKIP_REBUILD_BRO = ${SKIP_REBUILD_BRO}"
 echo "DATA_PATH        = ${DATA_PATH}"


### PR DESCRIPTION
## Contributor Comments

This PR addresses the requirement for the plugin to be a git repo for bro-pkg.  If the plugin is not a git repo ( for example it is the downloaded src for an RC ), a repo will be created.

## Testing
- download the pr
- copy to directory to a new location
- `rm -rd .git`
- `cd docker && run_end_to_end.sh` 

This assumes that you have the docker container built already, if not add --do-docker-build flag.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [-] Have you written or updated unit tests and or integration tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [-] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/metron-bro-plugin-kafka/37)
<!-- Reviewable:end -->
