### PR TITLE
METRON-2309 Add a Kafka "metadata.broker.list" for each log writer filter.

### DIFF
--- a/src/KafkaWriter.h
+++ b/src/KafkaWriter.h
@@ -75,6 +75,7 @@ private:
     map<string, string> kafka_conf;
     string topic_name;
     string topic_name_override;
+    string metadata_broker_list_override;
     threading::formatter::Formatter *formatter;
     RdKafka::Producer* producer;
     RdKafka::Topic* topic;


### PR DESCRIPTION
 Hi,
   in examples 4-5 in readme.md file it seems like you can set a different kafka broker list for each different bro filter, as in:

local http_filter: Log::Filter = [
        $name = "kafka-http",
        $writer = Log::WRITER_KAFKAWRITER,
        $config = table(
                ["metadata.broker.list"] = "localhost:9092"
        ),
        $path = "http"
    ];

However, looking at the code here, this is the case only for the topic_name. I fixed this.

Mauro


