### PR TITLE
METRON-2346: Update kafka plugin testing dependencies

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -188,9 +188,9 @@ testing scripts to be added to a pull request, and subsequently to a test suite.
 - `download_sample_pcaps.sh`: Downloads the sample pcaps to a specified directory. If they exist, it is a no-op
   
    > The sample pcaps are:
-   >  -  https://www.bro.org/static/traces/exercise-traffic.pcap 
+   >  -  https://github.com/bro/try-bro/blob/master/manager/static/pcaps/exercise_traffic.pcap
    >  -  http://downloads.digitalcorpora.org/corpora/network-packet-dumps/2008-nitroba/nitroba.pcap 
-   >  -  https://www.bro.org/static/traces/ssh.pcap 
+   >  -  https://github.com/bro/try-bro/raw/master/manager/static/pcaps/ssh.pcap
    >  -  https://github.com/markofu/pcaps/blob/master/PracticalPacketAnalysis/ppa-capture-files/ftp.pcap?raw=true 
    >  -  https://github.com/EmpowerSecurityAcademy/wireshark/blob/master/radius_localhost.pcapng?raw=true 
    >  -  https://github.com/kholia/my-pcaps/blob/master/VNC/07-vnc

--- a/docker/containers/bro-localbuild-container/Dockerfile
+++ b/docker/containers/bro-localbuild-container/Dockerfile
@@ -30,8 +30,10 @@ RUN yum -y groupinstall "Development Tools" && \
 COPY .screenrc /root
 
 # install bro
-RUN curl -L https://www.bro.org/downloads/bro-2.5.5.tar.gz | tar xvz
-WORKDIR bro-2.5.5/
+RUN git clone https://github.com/bro/bro
+WORKDIR bro/
+RUN git checkout v2.5.5
+RUN git submodule update --init --recursive
 RUN ./configure
 RUN make
 RUN make install

--- a/docker/scripts/docker_run_zookeeper_container.sh
+++ b/docker/scripts/docker_run_zookeeper_container.sh
@@ -78,5 +78,5 @@ rc=$?; if [[ ${rc} != 0 ]]; then
   exit ${rc}
 fi
 
-echo "Started the zookeeper container with networ ${NETWORK_NAME}"
+echo "Started the zookeeper container with network ${NETWORK_NAME}"
 

--- a/docker/scripts/download_sample_pcaps.sh
+++ b/docker/scripts/download_sample_pcaps.sh
@@ -87,7 +87,7 @@ for folder in nitroba example-traffic ssh ftp radius rfb; do
 done
 
 if [[ ! -f "${DATA_PATH}"/example-traffic/exercise-traffic.pcap ]]; then
-  wget https://www.bro.org/static/traces/exercise-traffic.pcap -O "${DATA_PATH}"/example-traffic/exercise-traffic.pcap
+  wget https://github.com/bro/try-bro/raw/master/manager/static/pcaps/exercise_traffic.pcap -O "${DATA_PATH}"/example-traffic/exercise-traffic.pcap
 fi
 
 if [[ ! -f "${DATA_PATH}"/nitroba/nitroba.pcap ]]; then
@@ -95,7 +95,7 @@ if [[ ! -f "${DATA_PATH}"/nitroba/nitroba.pcap ]]; then
 fi
 
 if [[ ! -f "${DATA_PATH}"/ssh/ssh.pcap ]]; then
-  wget https://www.bro.org/static/traces/ssh.pcap -O "${DATA_PATH}"/ssh/ssh.pcap
+  wget https://github.com/bro/try-bro/raw/master/manager/static/pcaps/ssh.pcap -O "${DATA_PATH}"/ssh/ssh.pcap
 fi
 
 if [[ ! -f "${DATA_PATH}"/ftp/ftp.pcap ]]; then


### PR DESCRIPTION
## Contributor Comments
As a part of the bro rename to zeek, our testing environment broke.  To test, run `./run_end_to_end.sh` and confirm it now succeeds.


## Pull Request Checklist
Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [X] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [X] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [X] Have you included steps or a guide to how the change may be verified and tested manually?
- [X] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?