### PR TITLE
METRON-2349: [BRO-PLUGIN-KAFKA] Fix hard coded topic_name in e2e tests

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -53,6 +53,10 @@ testing scripts to be added to a pull request, and subsequently to a test suite.
 
 - `build_bro_plugin.sh`: Runs `bro-pkg` to build and install the provided version of the plugin.
 - `configure_bro_plugin.sh`: Configures the plugin for the kafka container, and routes all traffic types.
+  ###### Parameters
+  ```bash
+  --kafka-topic                  [OPTIONAL] The kafka topic to configure. Default: bro"
+  ```
 - `process_data_file.sh`: Runs `bro -r` on the passed file
 
 

--- a/docker/in_docker_scripts/configure_bro_plugin.sh
+++ b/docker/in_docker_scripts/configure_bro_plugin.sh
@@ -25,11 +25,53 @@ shopt -s nocasematch
 # Configures the plugin for all the traffic types
 #
 
+function help {
+  echo " "
+  echo "usage: ${0}"
+  echo "    --kafka-topic                  [OPTIONAL] The kafka topic to configure. Default: bro"
+  echo "    -h/--help                      Usage information."
+  echo " "
+  echo " "
+}
+
+KAFKA_TOPIC=bro
+
+# Handle command line options
+for i in "$@"; do
+  case $i in
+  #
+  # KAFKA_TOPIC
+  #
+  #   --kafka-topic
+  #
+    --kafka-topic=*)
+      KAFKA_TOPIC="${i#*=}"
+      shift # past argument=value
+    ;;
+  #
+  # -h/--help
+  #
+    -h | --help)
+      help
+      exit 0
+      shift # past argument with no value
+    ;;
+  #
+  # Unknown option
+  #
+    *)
+      UNKNOWN_OPTION="${i#*=}"
+      echo "Error: unknown option: $UNKNOWN_OPTION"
+      help
+    ;;
+  esac
+done
+
 echo "Configuring kafka plugin"
 {
   echo "@load packages"
   echo "redef Kafka::logs_to_send = set(HTTP::LOG, DNS::LOG, Conn::LOG, DPD::LOG, FTP::LOG, Files::LOG, Known::CERTS_LOG, SMTP::LOG, SSL::LOG, Weird::LOG, Notice::LOG, DHCP::LOG, SSH::LOG, Software::LOG, RADIUS::LOG, X509::LOG, Known::DEVICES_LOG, RFB::LOG, Stats::LOG, CaptureLoss::LOG, SIP::LOG);"
-  echo "redef Kafka::topic_name = \"bro\";"
+  echo "redef Kafka::topic_name = \"${KAFKA_TOPIC}\";"
   echo "redef Kafka::tag_json = T;"
   echo "redef Kafka::kafka_conf = table([\"metadata.broker.list\"] = \"kafka:9092\");"
   echo "redef Kafka::logs_to_exclude = set(Conn::LOG, DHCP::LOG);"

--- a/docker/run_end_to_end.sh
+++ b/docker/run_end_to_end.sh
@@ -198,7 +198,7 @@ rc=$?; if [[ ${rc} != 0 ]]; then
 fi
 
 # Configure the bro plugin
-bash "${SCRIPT_DIR}"/docker_execute_configure_bro_plugin.sh
+bash "${SCRIPT_DIR}"/docker_execute_configure_bro_plugin.sh --kafka-topic="${KAFKA_TOPIC}"
 rc=$?; if [[ ${rc} != 0 ]]; then
   echo "ERROR> FAILED TO CONFIGURE PLUGIN.  CHECK LOGS  ${rc}"
   exit ${rc}

--- a/docker/scripts/docker_execute_configure_bro_plugin.sh
+++ b/docker/scripts/docker_execute_configure_bro_plugin.sh
@@ -31,12 +31,14 @@ function help {
   echo " "
   echo "usage: ${0}"
   echo "    --container-name                [OPTIONAL] The Docker container name. Default: metron-bro-plugin-kafka_bro_1"
+  echo "    --kafka-topic                   [OPTIONAL] The kafka topic to create. Default: bro"
   echo "    -h/--help                       Usage information."
   echo " "
   echo " "
 }
 
 CONTAINER_NAME=metron-bro-plugin-kafka_bro_1
+KAFKA_TOPIC=bro
 
 # Handle command line options
 for i in "$@"; do
@@ -50,7 +52,15 @@ for i in "$@"; do
       CONTAINER_NAME="${i#*=}"
       shift # past argument=value
     ;;
-
+  #
+  # KAFKA_TOPIC
+  #
+  #   --kafka-topic
+  #
+    --kafka-topic=*)
+      KAFKA_TOPIC="${i#*=}"
+      shift # past argument=value
+    ;;
   #
   # -h/--help
   #
@@ -59,7 +69,6 @@ for i in "$@"; do
       exit 0
       shift # past argument with no value
     ;;
-
   #
   # Unknown option
   #
@@ -71,11 +80,12 @@ for i in "$@"; do
   esac
 done
 
-echo "Running docker_execute_configure_bro_plugin with "
-echo "CONTAINER_NAME = $CONTAINER_NAME"
+echo "Running docker_execute_configure_bro_plugin.sh with "
+echo "CONTAINER_NAME = ${CONTAINER_NAME}"
+echo "KAFKA_TOPIC = ${KAFKA_TOPIC}"
 echo "==================================================="
 
-docker exec -w /root "${CONTAINER_NAME}" bash -c /root/built_in_scripts/configure_bro_plugin.sh
+docker exec -w /root "${CONTAINER_NAME}" bash -c "/root/built_in_scripts/configure_bro_plugin.sh --kafka-topic=\"${KAFKA_TOPIC}\""
 rc=$?; if [[ ${rc} != 0 ]]; then
   exit ${rc};
 fi


### PR DESCRIPTION
## Contributor Comments
Fixes e2e tests when a custom kafka topic is specified.  Previously everything would have completed without error, but the bro container would have sent to a hard coded `bro` topic.  This is based off of #42 for the time being, until that is merged and I will rebase on `master`.

### Testing
Run `./run_end_to_end.sh --kafka-topic=testing` and see that it works


## Pull Request Checklist
Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [X] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [X] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [X] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?