### PR TITLE
METRON-2357: Extends example 4 with a dynamic version

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,48 @@ event zeek_init() &priority=-10
 }
 ```
 
+#### Dynamically send each zeek log to a topic with its same name.
+
+ * ej. `CONN::LOG` logs are sent to the `conn` topic or `Known::CERTS_LOG` to the `known-certs` topic.
+
+```
+@load packages/metron-bro-plugin-kafka/Apache/Kafka
+redef Kafka::logs_to_send = set(DHCP::LOG, RADIUS::LOG, DNS::LOG);
+redef Kafka::topic_name = "";
+redef Kafka::tag_json = T;
+
+event zeek_init() &priority=-10
+{
+    for (stream_id in Log::active_streams) {
+        # Convert stream type enum to string
+        const stream_string: string = fmt("%s", stream_id);
+
+        # replace `::` by `_` from the log string name
+	    # ej. CONN::LOG to CONN_LOG or Known::CERTS_LOG to Known_CERTS_LOG
+        const stream_name: string = sub(stream_string, /::/, "_");
+
+        # lowercase the whole string for nomalization
+        const topic_name_lower: string = to_lower(stream_name);
+
+        # remove the _log at the of each topic name
+        const topic_name_under: string = sub(topic_name_lower, /_log$/, "");
+
+        # replace `_` by `-` for compatibility with acceptable Kafka topic naes
+        const topic_name: string = sub(topic_name_under, /_/, "-");
+
+        if (|Kafka::logs_to_send| == 0 || stream_id in Kafka::logs_to_send)
+        {
+            local log_filter: Log::Filter = [
+                $name = fmt("kafka-%s", stream_id),
+                $writer = Log::WRITER_KAFKAWRITER,
+                $path = fmt("%s", topic_name)
+            ];
+            Log::add_filter(stream_id, log_filter);
+        }
+    }
+}
+```
+
 ### Example 5 - Zeek log filtering
 
 You may want to configure zeek to filter log messages with certain characteristics from being sent to your kafka topics.  For instance, Apache Metron currently doesn't support IPv6 source or destination IPs in the default enrichments, so it may be helpful to filter those log messages from being sent to kafka (although there are [multiple ways](#notes) to approach this).  In this example we will do that that, and are assuming a somewhat standard zeek kafka plugin configuration, such that:


### PR DESCRIPTION
## Contributor Comments

- Extends the current [Example 4](https://github.com/apache/metron-bro-plugin-kafka#example-4---send-each-zeek-log-to-a-unique-topic)  to include a dynamic version.

It will demonstrate how to automatically send each zeek log to a topic with the same name.

For instance the `CONN::LOG` log to be sent to the `conn` topic or `Known::CERTS_LOG` to the `known-certs` topic without defining a `Log::Filter` for each of those.


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron's Bro kafka writer plugin.

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed via:
  ```
  bro-pkg test $GITHUB_USERNAME/metron-bro-plugin-kafka --version $BRANCH
  ```
- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Apache Metron's [Vagrant full-dev environment](https://github.com/apache/metron/tree/master/metron-deployment/development/centos6) or the equivalent?

